### PR TITLE
GC can now trace pointers in an EXTERNALSEXP

### DIFF
--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -646,7 +646,15 @@ static R_size_t R_NodesInUse = 0;
   case WEAKREFSXP: \
   case RAWSXP: \
   case S4SXP: \
+    break; \
   case EXTERNALSXP: \
+    { \
+      int i; \
+      SEXP* __end__ = (SEXP*)((uintptr_t)INTEGER(__n__) + LENGTH(__n__)); \
+      SEXP* __ptrs__ = __end__ - TRUELENGTH(__n__); \
+      while (__ptrs__ != __end__) \
+        dc__action__(*__ptrs__++, dc__extra__); \
+    } \
     break; \
   case STRSXP: \
   case EXPRSXP: \


### PR DESCRIPTION
This change is necessary for us to support "dispatch tables" in RIR,
because we will have pointers to R objects in an EXTERNALSEXP.

Specifically, the first part of the EXTERNALSEXP is opaque to the GC,
and is followed by an array of R pointers. The GC must be able to
trace those pointers. For example:

    typedef struct DispatchTable {
        unsigned magic; // opaque
        size_t length;  // opaque
        SEXP entry[];   // R pointers
    } DispatchTable;

To access the pointer array, we take a pointer to the beginning of
the struct, move it to the end of the struct, and then move it
*back* so it points to the beginning of the array.

We use the TRUELENGTH field to indicate the length of the array.

This change is backwards compatible, as all existing EXTERNALSEXP
have TRUELENGTH set to 0.