### PR TITLE
added cleanup handler

### DIFF
--- a/src/include/Rinternals.h
+++ b/src/include/Rinternals.h
@@ -1688,12 +1688,16 @@ typedef SEXP (*external_code_compile)(SEXP, SEXP);
 typedef SEXP (*external_code_to_expr)(SEXP);
 typedef SEXP (*external_code_materialize)(void*);
 typedef SEXP* (*external_code_keepAlive)(void*);
+typedef void (*external_code_cleanup)(void);
 extern external_code_to_expr externalCodeToExpr;
 extern external_code_materialize externalMaterialize;
 extern external_code_keepAlive externalKeepAlive;
+extern external_code_cleanup externalCleanup;
 extern void registerExternalCode(external_code_eval, external_closure_call,
                                  external_code_compile, external_code_to_expr,
-                                 external_code_materialize, external_code_keepAlive);
+                                 external_code_materialize, 
+                                 external_code_keepAlive,
+                                 external_code_cleanup);
 
 
 /* Defining NO_RINLINEDFUNS disables use to simulate platforms where

--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -538,17 +538,21 @@ static external_code_compile externalCodeCompile = NULL;
 external_code_to_expr externalCodeToExpr = NULL;
 external_code_materialize externalMaterialize = NULL;
 external_code_keepAlive externalKeepAlive = NULL;
+external_code_cleanup externalCleanup = NULL;
 
 void registerExternalCode(external_code_eval eval, external_closure_call call,
                           external_code_compile compiler,
                           external_code_to_expr toExpr,
-                          external_code_materialize materialize, external_code_keepAlive keepAlive) {
+                          external_code_materialize materialize,
+                          external_code_keepAlive keepAlive,
+                          external_code_cleanup cleanup) {
     externalCodeEval = eval;
     externalClosureCall = call;
     externalCodeCompile = compiler;
     externalCodeToExpr = toExpr;
     externalMaterialize = materialize;
 	externalKeepAlive = keepAlive;
+    externalCleanup = cleanup;
 }
 
 /* Return value of "e" evaluated in "rho". */

--- a/src/unix/sys-std.c
+++ b/src/unix/sys-std.c
@@ -1198,7 +1198,8 @@ void attribute_hidden NORET Rstd_CleanUp(SA_TYPE saveact, int status, int runLas
     default:
 	break;
     }
-    externalCleanup();
+    if (externalCleanup != NULL)
+        externalCleanup();
     R_RunExitFinalizers();
     CleanEd();
     if(saveact != SA_SUICIDE) KillAllDevices();

--- a/src/unix/sys-std.c
+++ b/src/unix/sys-std.c
@@ -1198,6 +1198,7 @@ void attribute_hidden NORET Rstd_CleanUp(SA_TYPE saveact, int status, int runLas
     default:
 	break;
     }
+    externalCleanup();
     R_RunExitFinalizers();
     CleanEd();
     if(saveact != SA_SUICIDE) KillAllDevices();


### PR DESCRIPTION
Adds a function `rirCleanup` which will be called when R exits.

Would be used by https://github.com/reactorlabs/rir/pull/474.